### PR TITLE
Modify Behavior of AoTCG Lizzie card

### DIFF
--- a/common/cards/advent-of-tcg/hermits/ldshadowlady-rare.ts
+++ b/common/cards/advent-of-tcg/hermits/ldshadowlady-rare.ts
@@ -20,7 +20,7 @@ const LDShadowLadyRare: Hermit = {
 	palette: 'advent_of_tcg',
 	background: 'advent_of_tcg',
 	rarity: 'rare',
-	tokens: 1,
+	tokens: 2,
 	type: 'terraform',
 	health: 290,
 	primary: {
@@ -34,7 +34,7 @@ const LDShadowLadyRare: Hermit = {
 		cost: ['terraform', 'terraform', 'any'],
 		damage: 90,
 		power:
-			"Move your opponent's active Hermit and any attached cards to an open slot on their board, if one is available. If there's no open slots available, their active Hermit takes 60hp additional damage.",
+			"Move your opponent's active Hermit and any attached cards to an open slot on their board, if one is available. If their Hermit can't be moved, their active Hermit takes 40hp additional damage.",
 	},
 	onAttach(
 		game: GameModel,
@@ -112,10 +112,9 @@ const LDShadowLadyRare: Hermit = {
 			(attack) => {
 				if (!attack.isAttacker(component.entity) || !attack.isType('secondary'))
 					return
-				if (!opponentHasMovableActive() || opponentPlayer.activeRow === null)
-					return
+				if (opponentPlayer.activeRow === null) return
 				if (pickedRow === null) {
-					attack.addDamage(component.entity, 60)
+					attack.addDamage(component.entity, 40)
 				} else {
 					game.swapRows(opponentPlayer.activeRow, pickedRow)
 				}

--- a/tests/unit/game/advent-of-tcg/effects/slimeball.test.ts
+++ b/tests/unit/game/advent-of-tcg/effects/slimeball.test.ts
@@ -6,7 +6,6 @@ import LDShadowLadyRare from 'common/cards/advent-of-tcg/hermits/ldshadowlady-ra
 import MonkeyfarmRare from 'common/cards/advent-of-tcg/hermits/monkeyfarm-rare'
 import DwarfImpulseRare from 'common/cards/alter-egos-iii/hermits/dwarfimpulse-rare'
 import KingJoelRare from 'common/cards/alter-egos-iii/hermits/kingjoel-rare'
-import PoePoeSkizzRare from 'common/cards/alter-egos-iii/hermits/poepoeskizz-rare'
 import String from 'common/cards/alter-egos/effects/string'
 import BadOmen from 'common/cards/alter-egos/single-use/bad-omen'
 import EnderPearl from 'common/cards/alter-egos/single-use/ender-pearl'
@@ -18,6 +17,7 @@ import GeminiTayRare from 'common/cards/default/hermits/geminitay-rare'
 import HypnotizdRare from 'common/cards/default/hermits/hypnotizd-rare'
 import Iskall85Common from 'common/cards/default/hermits/iskall85-common'
 import ZombieCleoRare from 'common/cards/default/hermits/zombiecleo-rare'
+import GeminiTayCommon from 'common/cards/default/hermits/geminitay-common'
 import BalancedItem from 'common/cards/default/items/balanced-common'
 import MinerItem from 'common/cards/default/items/miner-common'
 import CurseOfVanishing from 'common/cards/default/single-use/curse-of-vanishing'
@@ -200,12 +200,12 @@ describe('Test Slimeball', () => {
 		testGame(
 			{
 				playerOneDeck: [LDShadowLadyRare, GoldenAxe],
-				playerTwoDeck: [PoePoeSkizzRare, Slimeball, EnderPearl],
+				playerTwoDeck: [GeminiTayCommon, Slimeball, EnderPearl],
 				saga: function* (game) {
 					yield* playCardFromHand(game, LDShadowLadyRare, 'hermit', 0)
 					yield* endTurn(game)
 
-					yield* playCardFromHand(game, PoePoeSkizzRare, 'hermit', 0)
+					yield* playCardFromHand(game, GeminiTayCommon, 'hermit', 0)
 					yield* playCardFromHand(game, Slimeball, 'attach', 0)
 					expect(
 						game.getPickableSlots(EnderPearl.attachCondition),
@@ -217,7 +217,9 @@ describe('Test Slimeball', () => {
 					yield* attack(game, 'secondary')
 					expect(game.state.pickRequests).toStrictEqual([])
 					expect(game.opponentPlayer.activeRow?.health).toBe(
-						PoePoeSkizzRare.health - LDShadowLadyRare.secondary.damage,
+						GeminiTayCommon.health -
+							LDShadowLadyRare.secondary.damage -
+							40 /** Extra Damage from Lizzie's ability**/,
 					)
 					yield* endTurn(game)
 
@@ -233,8 +235,9 @@ describe('Test Slimeball', () => {
 					)
 					expect(game.opponentPlayer.activeRow?.index).toBe(1)
 					expect(game.opponentPlayer.activeRow?.health).toBe(
-						PoePoeSkizzRare.health -
+						GeminiTayCommon.health -
 							LDShadowLadyRare.secondary.damage -
+							40 /** Extra Damage from Lizzie's ability**/ -
 							40 /** Golden Axe damage */ -
 							LDShadowLadyRare.secondary.damage,
 					)

--- a/tests/unit/game/advent-of-tcg/hermits/ldshadowlady-rare.test.ts
+++ b/tests/unit/game/advent-of-tcg/hermits/ldshadowlady-rare.test.ts
@@ -3,6 +3,7 @@ import BerryBush from 'common/cards/advent-of-tcg/effects/berry-bush'
 import LDShadowLadyRare from 'common/cards/advent-of-tcg/hermits/ldshadowlady-rare'
 import EthosLabCommon from 'common/cards/default/hermits/ethoslab-common'
 import Crossbow from 'common/cards/default/single-use/crossbow'
+import Slimeball from 'common/cards/advent-of-tcg/effects/slimeball'
 import query from 'common/components/query'
 import {
 	attack,
@@ -41,6 +42,34 @@ describe('Test Lizzie Evict', () => {
 		)
 	})
 
+	test('Slimeball triggers Evict damage', () => {
+		testGame(
+			{
+				playerOneDeck: [EthosLabCommon],
+				playerTwoDeck: [LDShadowLadyRare, Slimeball],
+				saga: function* (game) {
+					yield* playCardFromHand(game, EthosLabCommon, 'hermit', 0)
+					yield* endTurn(game)
+
+					yield* playCardFromHand(game, LDShadowLadyRare, 'hermit', 0)
+					yield* playCardFromHand(
+						game,
+						Slimeball,
+						'attach',
+						0,
+						game.opponentPlayerEntity,
+					)
+					yield* attack(game, 'secondary')
+					expect(game.opponentPlayer.activeRow?.health).toBe(
+						EthosLabCommon.health - LDShadowLadyRare.secondary.damage - 40,
+					)
+					expect(game.opponentPlayer.activeRow?.index).toBe(0)
+				},
+			},
+			{startWithAllCards: true, noItemRequirements: true},
+		)
+	})
+
 	test('Canceling Evict then dealing bonus damage for full board', () => {
 		testGame(
 			{
@@ -73,7 +102,7 @@ describe('Test Lizzie Evict', () => {
 					yield* attack(game, 'secondary')
 					expect(game.state.pickRequests).toHaveLength(0)
 					expect(game.opponentPlayer.activeRow?.health).toBe(
-						EthosLabCommon.health - LDShadowLadyRare.secondary.damage - 60,
+						EthosLabCommon.health - LDShadowLadyRare.secondary.damage - 40,
 					)
 					expect(game.opponentPlayer.activeRow?.index).toBe(0)
 				},


### PR DESCRIPTION
- Changes description: `Move your opponent's active Hermit and any attached cards to an open slot on their board, if one is available. If their Hermit can't be moved, their active Hermit takes 40hp additional damage.`
- Updates token cost to 2 to reflect improved ability
- Tests, of course. I had to switch a Slimeball test to use a 300HP hermit because Lizzie's damage was too high after the change.